### PR TITLE
Move CodeGenerator to codegen package, fixed a typo.

### DIFF
--- a/trans/src/wich/Trans.java
+++ b/trans/src/wich/Trans.java
@@ -29,14 +29,10 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.STGroupFile;
-import which.parser.WichLexer;
-import which.parser.WichParser;
 import wich.codegen.ModelConverter;
 import wich.codegen.model.OutputModelObject;
-import wich.parser.CodeGenerator;
-import wich.parser.SymbolTableConstructor;
-import wich.parser.TypeAnnotator;
-import wich.parser.TypeChecker;
+import wich.codegen.CodeGenerator;
+import wich.parser.*;
 import wich.semantics.SymbolTable;
 
 import java.io.FileOutputStream;

--- a/trans/src/wich/codegen/CodeGenerator.java
+++ b/trans/src/wich/codegen/CodeGenerator.java
@@ -21,10 +21,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-package wich.parser;
+package wich.codegen;
 
-import which.parser.WichBaseVisitor;
 import wich.codegen.model.OutputModelObject;
+import wich.parser.WichBaseVisitor;
 import wich.semantics.SymbolTable;
 
 public class CodeGenerator extends WichBaseVisitor<OutputModelObject> {

--- a/trans/src/wich/parser/SymbolTableConstructor.java
+++ b/trans/src/wich/parser/SymbolTableConstructor.java
@@ -25,8 +25,6 @@ package wich.parser;
 
 import org.antlr.symtab.Scope;
 import org.antlr.symtab.VariableSymbol;
-import which.parser.WichBaseListener;
-import which.parser.WichParser;
 import wich.semantics.SymbolTable;
 
 public class SymbolTableConstructor extends WichBaseListener{

--- a/trans/src/wich/parser/TypeAnnotator.java
+++ b/trans/src/wich/parser/TypeAnnotator.java
@@ -23,7 +23,6 @@ SOFTWARE.
 */
 package wich.parser;
 
-import which.parser.WichBaseVisitor;
 import wich.semantics.SymbolTable;
 
 public class TypeAnnotator extends WichBaseVisitor {

--- a/trans/src/wich/parser/TypeChecker.java
+++ b/trans/src/wich/parser/TypeChecker.java
@@ -23,7 +23,6 @@ SOFTWARE.
 */
 package wich.parser;
 
-import which.parser.WichBaseVisitor;
 import wich.semantics.SymbolTable;
 
 public class TypeChecker extends WichBaseVisitor {

--- a/trans/src/wich/parser/Wich.g4
+++ b/trans/src/wich/parser/Wich.g4
@@ -24,6 +24,7 @@ SOFTWARE.
 
 grammar Wich;
 
+
 file : script ;
 
 script : (statement | function)+ EOF ;

--- a/trans/test/CompilerFacade.java
+++ b/trans/test/CompilerFacade.java
@@ -25,9 +25,9 @@ SOFTWARE.
 import org.antlr.symtab.GlobalScope;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import which.parser.WichLexer;
-import which.parser.WichParser;
 import wich.parser.SymbolTableConstructor;
+import wich.parser.WichLexer;
+import wich.parser.WichParser;
 import wich.semantics.SymbolTable;
 
 public class CompilerFacade {
@@ -44,7 +44,6 @@ public class CompilerFacade {
 		ParseTreeWalker walker = new ParseTreeWalker();
 		SymbolTableConstructor symtabConstructor = new SymbolTableConstructor(symtab);
 		walker.walk(symtabConstructor, tree);
-
 		return symtab.getGlobalScope();
 	}
 }

--- a/trans/test/TestSymbolDefine.java
+++ b/trans/test/TestSymbolDefine.java
@@ -23,7 +23,6 @@ SOFTWARE.
 */
 
 import org.antlr.symtab.GlobalScope;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Moved CodeGenerator to codegen after discussion. Fixed a type which uses which (which shoud be 'wich') as the language name.