### PR TITLE
Fix and adjustment in light of codeGen

### DIFF
--- a/trans/src/wich/codegen/CodeGenerator.java
+++ b/trans/src/wich/codegen/CodeGenerator.java
@@ -424,11 +424,13 @@ public class CodeGenerator extends WichBaseVisitor<OutputModelObject> {
 		if (((WFunctionSymbol) currentScope.resolve(funcName)).getType()!= null) {
 			fc.reType = ((WFunctionSymbol) currentScope.resolve(funcName)).getType().getName();
 		}
-		List<WichParser.ExprContext> expr = ctx.call_expr().expr_list().expr();
-		for (WichParser.ExprContext e : expr) {
-			fc.args.add((Expr)visit(e));
-			for (TmpVarDef t :((Expr)visit(e)).tmpVarDefs) {
-				fc.tmpVarDefs.add(t);
+		if(ctx.call_expr().expr_list() != null){
+			List<WichParser.ExprContext> expr = ctx.call_expr().expr_list().expr();
+			for (WichParser.ExprContext e : expr) {
+				fc.args.add((Expr)visit(e));
+				for (TmpVarDef t :((Expr)visit(e)).tmpVarDefs) {
+					fc.tmpVarDefs.add(t);
+				}
 			}
 		}
 		if (fc.reType != null && isTempVarNeeded(ctx.getParent())) {

--- a/trans/src/wich/semantics/SymbolTableConstructor.java
+++ b/trans/src/wich/semantics/SymbolTableConstructor.java
@@ -38,6 +38,7 @@ public class SymbolTableConstructor extends WichBaseListener {
 
 	private final SymbolTable symtab;
 	private Scope currentScope;
+	private int numOfBlocks;
 
 	public SymbolTableConstructor(SymbolTable symtab) {
 		this.symtab = symtab;
@@ -65,7 +66,7 @@ public class SymbolTableConstructor extends WichBaseListener {
 		currentScope.define(f);
 		//resolve return type of the method
 		if (ctx.type() != null)
-			f.setType((Type) currentScope.resolve(ctx.type().getText()));
+			f.setType((Type) symtab.PREDEFINED.getSymbol(ctx.type().getText()));
 		else
 			f.setType(null);
 		pushScope(f);
@@ -78,7 +79,15 @@ public class SymbolTableConstructor extends WichBaseListener {
 
 	@Override
 	public void enterBlock(@NotNull WichParser.BlockContext ctx) {
-		WBlock l = new WBlock("local");
+		WBlock l;
+		if (currentScope instanceof WBlock)
+			l = new WBlock((WBlock)currentScope);
+		if (currentScope instanceof WFunctionSymbol)
+			l = new WBlock((WFunctionSymbol) currentScope);
+		else{
+			l = new WBlock(numOfBlocks);
+			numOfBlocks++;
+		}
 		ctx.scope = l;
 		currentScope.define(l);
 		pushScope(l);

--- a/trans/src/wich/semantics/type/WBlock.java
+++ b/trans/src/wich/semantics/type/WBlock.java
@@ -25,7 +25,28 @@ SOFTWARE.
 import org.antlr.symtab.SymbolWithScope;
 
 public class WBlock extends SymbolWithScope {
-	public WBlock(String name) {
-		super(name);
+	public final int index;
+	public int numOfNested;
+
+	//when parent scope is global
+	public WBlock(int blocksInGlobal) {
+		super("local" + "_" + blocksInGlobal);
+		index = blocksInGlobal;
+		numOfNested = 0;
 	}
+
+	//when parent scope is function
+	public WBlock(WFunctionSymbol function) {
+		super("local" + "_" + function.numOfNested);
+		index = function.numOfNested++;
+		numOfNested = 0;
+	}
+
+	//when parent scope is local block
+	public WBlock(WBlock block) {
+		super("local" + "_" + block.numOfNested);
+		index = block.numOfNested++;
+		numOfNested = 0;
+	}
+
 }

--- a/trans/src/wich/semantics/type/WFunctionSymbol.java
+++ b/trans/src/wich/semantics/type/WFunctionSymbol.java
@@ -26,6 +26,7 @@ package wich.semantics.type;
 import org.antlr.symtab.FunctionSymbol;
 
 public class WFunctionSymbol extends FunctionSymbol {
+	public int numOfNested;
 	public WFunctionSymbol(String funcName) {
 		super(funcName);
 	}

--- a/trans/src/wich/semantics/type/WString.java
+++ b/trans/src/wich/semantics/type/WString.java
@@ -25,6 +25,6 @@ package wich.semantics.type;
 
 public class WString extends WBuiltInTypeSymbol {
 	public WString() {
-		super("String", TYPE.STRING);
+		super("string", TYPE.STRING);
 	}
 }

--- a/trans/test/TestSymbolDefs.java
+++ b/trans/test/TestSymbolDefs.java
@@ -110,7 +110,7 @@ public class TestSymbolDefs {
 		String expecting =
 			"global {\n" +
 			"    f {\n" +
-			"        local {\n" +
+			"        local_0 {\n" +
 			"        }\n" +
 
 			"    }\n" +
@@ -127,7 +127,7 @@ public class TestSymbolDefs {
 			"    f {\n" +
 			"        f.x:int\n" +
 			"        f.y:[]\n" +
-			"        local {\n" +
+			"        local_0 {\n" +
 			"        }\n" +
 			"    }\n" +
 			"}\n";
@@ -141,9 +141,9 @@ public class TestSymbolDefs {
 		String expecting =
 			"global {\n" +
 			"    f {\n" +
-			"        local {\n" +
-			"            local.i:int\n" +
-			"            local.c:string\n" +
+			"        local_0 {\n" +
+			"            local_0.i:int\n" +
+			"            local_0.c:string\n" +
 			"        }\n" +
 			"    }\n" +
 			"}\n";
@@ -157,10 +157,10 @@ public class TestSymbolDefs {
 		String expecting =
 			"global {\n" +
 			"    f {\n" +
-			"        local {\n" +
-			"            local.i:int\n" +
-			"            local {\n" +
-			"                local.c:string\n" +
+			"        local_0 {\n" +
+			"            local_0.i:int\n" +
+			"            local_0 {\n" +
+			"                local_0.c:string\n" +
 			"            }\n" +
 			"        }\n" +
 			"    }\n" +
@@ -176,10 +176,10 @@ public class TestSymbolDefs {
 			"global {\n" +
 			"    f {\n" +
 			"        f.x:int\n" +
-			"        local {\n" +
-			"            local.i:int\n" +
-			"            local {\n" +
-			"                local.c:string\n" +
+			"        local_0 {\n" +
+			"            local_0.i:int\n" +
+			"            local_0 {\n" +
+			"                local_0.c:string\n" +
 			"            }\n" +
 			"        }\n" +
 			"    }\n" +

--- a/trans/test/TestTypeAnnotation.java
+++ b/trans/test/TestTypeAnnotation.java
@@ -141,7 +141,7 @@ public class TestTypeAnnotation {
 	public void testRecursion() throws Exception {
 		String input =
 				"func fib(x:int) : int {\n" +
-				"   if (x == 0 || x == 1) {\n" +
+				"   if (x == 0 || (x == 1)) {\n" +
 				"       return x\n" +
 				"   }\n" +
 				"   return fib(x-1) + fib(x-2)\n" +
@@ -156,18 +156,19 @@ public class TestTypeAnnotation {
 				"==:boolean\n" +
 				"||:boolean\n" +
 				"x:int\n" +
-				"fib(x-1):int\n" +
 				"x:int\n" +
 				"1:int\n" +
 				"-:int\n" +
-				"fib(x-2):int\n" +
+				"fib(x-1):int\n" +
 				"x:int\n" +
 				"2:int\n" +
 				"-:int\n" +
+				"fib(x-2):int\n" +
 				"+:int\n" +
-				"fib(5):int\n"+
-				"5:int\n";
-		annotateTypeAndCheck(input, expected);
+				"5:int\n" +
+				"fib(5):int\n";
+
+				annotateTypeAndCheck(input, expected);
 	}
 
 	@Test

--- a/trans/test/t6.w
+++ b/trans/test/t6.w
@@ -1,5 +1,5 @@
 func fib(x:int) : int {
-	if (x == 0 || x == 1) {
+	if (x == 0 || (x == 1)) {
 		return x
 	}
 	return fib(x-1) + fib(x-2)


### PR DESCRIPTION
Changes in SymbolTableConstructor, TypeHelper, CodeGenerator as well as test cases to make things consistent, and fix a few mistakes. Several notes:
1. wich has the type "string", and it should be up to the CodeGenerator to generate whatever name for the string type in target language.
2. wich operators have no precedence, so remember to add parentheses when you do (x ==0) || (x ==1) in test cases.
3. Current dump functions do not generate strings in the desired order.